### PR TITLE
Fix blog index logic for single-post state and refine empty state typ…

### DIFF
--- a/src/templates/src/blog_index.html
+++ b/src/templates/src/blog_index.html
@@ -59,8 +59,8 @@
                     {{ template "blog_list_item.html" . }}
                 {{ end }}
             </div>
-        {{ else }}
-            <div class="f3">There are no blog posts for this project yet.</div>
+        {{ else if not .FirstPost}}
+            <div class="f5">There are no blog posts for this project yet.</div>
         {{ end }}
         <div class="flex flex-column g2">
             <hr>


### PR DESCRIPTION
This PR addresses Issue #35 regarding the inconsistent "no blog posts" message on the project index page.

The logic was previously only checking the .Posts slice (the grid of older posts), which led to the "no posts" notification appearing even when a single featured .FirstPost was present. I have updated the conditional to ensure the message only displays when both .Posts and .FirstPost are empty.

Additionally, I've updated the empty-state notification typography from f3 to f5 to better align with the site's utility-first CSS scale and provide a more subtle, professional UI.

Empty State (f5 Typography Fix):
<img width="480" height="167" alt="Screenshot 2026-04-20 at 11 47 27 PM" src="https://github.com/user-attachments/assets/80b26dda-d150-4198-a935-5e3ab18dc7a9" />

<br><br>
Single Post Verification (Logic Fix):
<img width="974" height="485" alt="Screenshot 2026-04-20 at 11 47 05 PM" src="https://github.com/user-attachments/assets/4827bc06-280e-419e-a06e-177b0716777d" />
