### PR TITLE
add linkify custom regex to excluding parenthesis in the end of link

### DIFF
--- a/src/parsing/parsing.go
+++ b/src/parsing/parsing.go
@@ -2,6 +2,7 @@ package parsing
 
 import (
 	"bytes"
+	"regexp"
 
 	"github.com/yuin/goldmark/parser"
 	"github.com/yuin/goldmark/renderer/html"
@@ -106,6 +107,9 @@ type MarkdownOptions struct {
 	Education bool
 }
 
+// modified from https://github.com/yuin/goldmark/blob/master/extension/linkify.go (urlRegexp)
+var customLinkifyURLRegex = regexp.MustCompile(`^(?:http|https|ftp)://[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-z]+(?::\d+)?(?:[/#?](?:[-a-zA-Z0-9@:%_+.~#$!?&/=;,'">\^{}\[\]` + "`" + `]|\([-a-zA-Z0-9@:%_+~#$!?&/=;'">\^{}\[\]` + "`" + `]|\)[-a-zA-Z0-9@:%_+~#$!?&/=;'">\^{}\[\]` + "`" + `])*)?`) //nolint:golint,lll
+
 func makeGoldmark(rawHTML bool, opts ...goldmark.Option) goldmark.Markdown {
 	// We need to re-create Goldmark's default parsers to disable HTML parsing.
 	// Or enable it again. yay
@@ -131,6 +135,9 @@ func makeGoldmark(rawHTML bool, opts ...goldmark.Option) goldmark.Markdown {
 		util.Prioritized(parser.NewAutoLinkParser(), 300),
 		// util.Prioritized(parser.NewRawHTMLParser(), 400),
 		util.Prioritized(parser.NewEmphasisParser(), 500),
+		util.Prioritized(extension.NewLinkifyParser(
+			extension.WithLinkifyURLRegexp(customLinkifyURLRegex),
+		), 600),
 	}
 
 	if rawHTML {

--- a/src/parsing/parsing.go
+++ b/src/parsing/parsing.go
@@ -108,7 +108,7 @@ type MarkdownOptions struct {
 }
 
 // modified from https://github.com/yuin/goldmark/blob/master/extension/linkify.go (urlRegexp)
-var customLinkifyURLRegex = regexp.MustCompile(`^(?:http|https|ftp)://[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-z]+(?::\d+)?(?:[/#?](?:[-a-zA-Z0-9@:%_+.~#$!?&/=;,'">\^{}\[\]` + "`" + `]|\([-a-zA-Z0-9@:%_+~#$!?&/=;'">\^{}\[\]` + "`" + `]|\)[-a-zA-Z0-9@:%_+~#$!?&/=;'">\^{}\[\]` + "`" + `])*)?`) //nolint:golint,lll
+var customLinkifyURLRegex = regexp.MustCompile(`^(?:http|https|ftp)://[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-z]+(?::\d+)?(?:[/#?](?:[-a-zA-Z0-9@:%_+.~#$!?&/=;,'">\^{}\[\]` + "`" + `]|\([-a-zA-Z0-9@:%_+~#$!?&/=;'">\^{}\[\]` + "`" + `]|\)[-a-zA-Z0-9@:%_+~#$!?&/=;'">\^{}\[\]` + "`" + `])*)?`)
 
 func makeGoldmark(rawHTML bool, opts ...goldmark.Option) goldmark.Markdown {
 	// We need to re-create Goldmark's default parsers to disable HTML parsing.

--- a/src/parsing/parsing_test.go
+++ b/src/parsing/parsing_test.go
@@ -38,12 +38,16 @@ And here's my favorite YouTube video:
 https://youtu.be/dQw4w9WgXcQ
 
 I hope you like it as much as I do.
+
+If you paste a link in parentheses (like https://handmade.network/), the site will pick up the closing parenthesis as part of the link. This is jank.
 `
 	t.Run("Real post Markdown", func(t *testing.T) {
 		html := ParseMarkdown(md, PostMarkdown)
 		t.Log(html)
 		assert.Contains(t, html, `<img src="coolimage.png"`)
 		assert.Contains(t, html, "<iframe")
+		assert.NotContains(t, html, `<a href="https://handmade.network/)">https://handmade.network/)</a>`)
+		assert.Contains(t, html, `<a href="https://handmade.network/">https://handmade.network/</a>`)
 	})
 	t.Run("Post edit preview Markdown", func(t *testing.T) {
 		html := ParseMarkdown(md, PostEditPreviewMarkdown)
@@ -51,6 +55,8 @@ I hope you like it as much as I do.
 		assert.Contains(t, html, `<img src="coolimage.png"`)
 		assert.Contains(t, html, `<img src="https://img.youtube.com/vi/dQw4w9WgXcQ/hqdefault.jpg"`)
 		assert.NotContains(t, html, "<iframe")
+		assert.NotContains(t, html, `<a href="https://handmade.network/)">https://handmade.network/)</a>`)
+		assert.Contains(t, html, `<a href="https://handmade.network/">https://handmade.network/</a>`)
 	})
 	t.Run("Post preview Markdown", func(t *testing.T) {
 		html := ParseMarkdown(md, PostPreviewMarkdown)
@@ -58,6 +64,8 @@ I hope you like it as much as I do.
 		assert.Contains(t, html, `<img src="coolimage.png"`)
 		assert.Contains(t, html, `<a href="https://youtu.be/dQw4w9WgXcQ"`)
 		assert.NotContains(t, html, "<iframe")
+		assert.NotContains(t, html, `<a href="https://handmade.network/)">https://handmade.network/)</a>`)
+		assert.Contains(t, html, `<a href="https://handmade.network/">https://handmade.network/</a>`)
 	})
 	t.Run("Plaintext Markdown", func(t *testing.T) {
 		html := ParseMarkdown(md, PlaintextMarkdown)
@@ -66,6 +74,8 @@ I hope you like it as much as I do.
 		assert.NotContains(t, html, `<a`)
 		assert.NotContains(t, html, "<iframe")
 		assert.NotContains(t, html, "\n", "Plain text markdown is intended for OpenGraph descriptions and therefore shouldn't contain newlines")
+		assert.NotContains(t, html, `<a href="https://handmade.network/)">https://handmade.network/)</a>`)
+		assert.NotContains(t, html, `<a href="https://handmade.network/">https://handmade.network/</a>`)
 	})
 }
 

--- a/src/parsing/parsing_test.go
+++ b/src/parsing/parsing_test.go
@@ -73,8 +73,6 @@ If you paste a link in parentheses (like https://handmade.network/), the site sh
 		assert.NotContains(t, html, `<a`)
 		assert.NotContains(t, html, "<iframe")
 		assert.NotContains(t, html, "\n", "Plain text markdown is intended for OpenGraph descriptions and therefore shouldn't contain newlines")
-		assert.NotContains(t, html, `<a href="https://handmade.network/)">https://handmade.network/)</a>`)
-		assert.NotContains(t, html, `<a href="https://handmade.network/">https://handmade.network/</a>`)
 	})
 }
 

--- a/src/parsing/parsing_test.go
+++ b/src/parsing/parsing_test.go
@@ -54,7 +54,6 @@ If you paste a link in parentheses (like https://handmade.network/), the site sh
 		assert.Contains(t, html, `<img src="coolimage.png"`)
 		assert.Contains(t, html, `<img src="https://img.youtube.com/vi/dQw4w9WgXcQ/hqdefault.jpg"`)
 		assert.NotContains(t, html, "<iframe")
-		assert.NotContains(t, html, `<a href="https://handmade.network/)">https://handmade.network/)</a>`)
 		assert.Contains(t, html, `<a href="https://handmade.network/">https://handmade.network/</a>`)
 	})
 	t.Run("Post preview Markdown", func(t *testing.T) {
@@ -63,7 +62,6 @@ If you paste a link in parentheses (like https://handmade.network/), the site sh
 		assert.Contains(t, html, `<img src="coolimage.png"`)
 		assert.Contains(t, html, `<a href="https://youtu.be/dQw4w9WgXcQ"`)
 		assert.NotContains(t, html, "<iframe")
-		assert.NotContains(t, html, `<a href="https://handmade.network/)">https://handmade.network/)</a>`)
 		assert.Contains(t, html, `<a href="https://handmade.network/">https://handmade.network/</a>`)
 	})
 	t.Run("Plaintext Markdown", func(t *testing.T) {

--- a/src/parsing/parsing_test.go
+++ b/src/parsing/parsing_test.go
@@ -46,7 +46,6 @@ If you paste a link in parentheses (like https://handmade.network/), the site sh
 		t.Log(html)
 		assert.Contains(t, html, `<img src="coolimage.png"`)
 		assert.Contains(t, html, "<iframe")
-		assert.NotContains(t, html, `<a href="https://handmade.network/)">https://handmade.network/)</a>`)
 		assert.Contains(t, html, `<a href="https://handmade.network/">https://handmade.network/</a>`)
 	})
 	t.Run("Post edit preview Markdown", func(t *testing.T) {

--- a/src/parsing/parsing_test.go
+++ b/src/parsing/parsing_test.go
@@ -39,7 +39,7 @@ https://youtu.be/dQw4w9WgXcQ
 
 I hope you like it as much as I do.
 
-If you paste a link in parentheses (like https://handmade.network/), the site will pick up the closing parenthesis as part of the link. This is jank.
+If you paste a link in parentheses (like https://handmade.network/), the site should not pick up the closing parenthesis as part of the link.
 `
 	t.Run("Real post Markdown", func(t *testing.T) {
 		html := ParseMarkdown(md, PostMarkdown)


### PR DESCRIPTION
i added some push to the website for following issue https://github.com/HandmadeNetwork/hmn/issues/31

this https://handmade.network/), is a valid link as i check in here https://0mg.github.io/tools/uri/
but turns out github doesn't render '),' as part of the link
so i add custom config url regex for linkify, 

i remove the `(` and `)` from ```[-a-zA-Z0-9@:%_+.~#$!?&/=\(\);,'">\^{}\[\]`]``` and after that i add a condition `or`  if we find `(` or `)` it must be followed by ```[-a-zA-Z0-9@:%_+~#$!?&/=;'">\^{}\[\]`]``` excepting `,` and `.` to make `(` or `)` as a part of the link, otherwise not

original regex for linkify is (default from goldmark): 
from: https://github.com/yuin/goldmark/blob/master/extension/linkify.go

```
^(?:http|https|ftp)://[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-z]+(?::\d+)?(?:[/#?][-a-zA-Z0-9@:%_+.~#$!?&/=\(\);,'">\^{}\[\]`]*)?
```

and modified version is like this
```
^(?:http|https|ftp)://[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-z]+(?::\d+)?(?:[/#?](?:[-a-zA-Z0-9@:%_+.~#$!?&/=;,'">\^{}\[\]`]|\([-a-zA-Z0-9@:%_+~#$!?&/=;'">\^{}\[\]`]|\)[-a-zA-Z0-9@:%_+~#$!?&/=;'">\^{}\[\]`])*)?
```

the wasm build is error for me in ```hmn\src\parsing\wasm\parsingmain.go:14``` ```undefined: parsing.ForumPreviewMarkdown``` so i replace it to ```PostPreviewMarkdown``` only just to test and i din't commit them.

sorry if my explanation sound confusing, i try my best to write this